### PR TITLE
rename dozzle → ocrd-logview

### DIFF
--- a/ocrd_monitor/docker-compose.yml
+++ b/ocrd_monitor/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - ${MANAGER_KEY}:/id_rsa
       - shared:/run/lock/ocrd.jobs
 
-  dozzle:
+  ocrd-logview:
     image: amir20/dozzle:latest
     volumes:
       # double slash is mandatory to support windows


### PR DESCRIPTION
just seems more appropriate. Must also be updated in ocrd_kitodo after merging.