### PR TITLE
Dockerfile labels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,19 +53,6 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Generate image metadata
-      if: steps.cache.outputs.cache-hit != 'true'
-      id: meta
-      uses: docker/metadata-action@v4
-      with:
-        images: ${{ env.IMAGE_NAME }}
-        labels: |
-          org.opencontainers.image.title=OCR-D Manager
-          org.opencontainers.image.version=${{ github.event.inputs.image-tag }}
-          org.opencontainers.image.revision=${{ env.vcs_ref }}
-          org.opencontainers.image.created=${{ env.build_date }}
-        tags: ${{ github.event.inputs.image-tag }}
           
     - name: Build the OCR-D Manager image "${{ env.IMAGE_NAME }}:${{ github.event.inputs.image-tag }}" and deploy to GitHub Container Repository
       if: steps.cache.outputs.cache-hit != 'true'
@@ -73,8 +60,7 @@ jobs:
       with:
          context: .
          push: true
-         tags: ${{ steps.meta.outputs.tags }}
-         labels: ${{ steps.meta.outputs.labels }}
+         tags: ${{ env.IMAGE_NAME }}:${{ github.event.inputs.image-tag }}
          build-args: |
             BUILD_DATE=${{ env.build_date }}
             VCS_REF=${{ env.vcs_ref }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,22 @@
 # ocrd/core # ubuntu:18.04
 FROM ocrd/core:latest
 
-MAINTAINER markus.weigelt@slub-dresden.de
 ARG VCS_REF
 ARG BUILD_DATE
 LABEL \
     maintainer="https://slub-dresden.de" \
+    org.label-schema.vendor="Saxon State and University Library Dresden" \
+    org.label-schema.name="OCR-D Manager" \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url="https://github.com/slub/ocrd_manager" \
     org.label-schema.build-date=$BUILD_DATE
+    org.opencontainers.image.vendor="Saxon State and University Library Dresden" \
+    org.opencontainers.image.title="OCR-D Manager" \
+    org.opencontainers.image.description="Frontend for OCR-D Controller"
+    org.opencontainers.image.source="https://github.com/slub/ocrd_manager"
+    org.opencontainers.image.documentation="https://github.com/slub/ocrd_manager/blob/${VCS_REF}/README.md"
+    org.opencontainers.image.revision=$VCS_REF
+    org.opencontainers.image.created=$BUILD_DATE
 
 ARG KITODO_MQ_CLIENT_VERSION=0.2
 


### PR DESCRIPTION
Move all labels to dockerfile and extend existing with org.opencontainers.image labels.