### PR TITLE
process_images.sh: allow skipping workspace validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ where OPTIONS can be any/all of:
  --script SCRIPT    overall script of the material to process via OCR
  --workflow FILE    workflow file to use for processing, default:
                     ocr-workflow-default.sh
+ --no-validate      skip comprehensive validation of workflow results
  --img-subdir IMG   name of the subdirectory to read images from, default:
                     images
  --ocr-subdir OCR   name of the subdirectory to write OCR results to, default:
@@ -162,6 +163,7 @@ process_mets.sh [OPTIONS] METS
 where OPTIONS can be any/all of:
  --workflow FILE    workflow file to use for processing, default:
                     ocr-workflow-default.sh
+ --no-validate      skip comprehensive validation of workflow results
  --pages RANGE      selection of physical page range to process
  --img-grp GRP      fileGrp to read input images from, default:
                     DEFAULT

--- a/process_images.sh
+++ b/process_images.sh
@@ -17,6 +17,7 @@ parse_args() {
   PROCESS_ID=
   TASK_ID=
   WORKFLOW=/workflows/ocr-workflow-default.sh
+  VALIDATE=1
   IMAGES_SUBDIR=images
   RESULT_SUBDIR=ocr/alto
   while (($#)); do
@@ -31,6 +32,7 @@ where OPTIONS can be any/all of:
  --script SCRIPT    overall script of the material to process via OCR
  --workflow FILE    workflow file to use for processing, default:
                     $WORKFLOW
+ --no-validate      skip comprehensive validation of workflow results
  --img-subdir IMG   name of the subdirectory to read images from, default:
                     $IMAGES_SUBDIR
  --ocr-subdir OCR   name of the subdirectory to write OCR results to, default:
@@ -60,6 +62,7 @@ EOF
       --lang) LANGUAGE="$2"; shift;;
       --script) SCRIPT="$2"; shift;;
       --workflow) WORKFLOW="$2"; shift;;
+      --no-validate) VALIDATE=0;;
       --img-subdir) IMAGES_SUBDIR="$2"; shift;;
       --ocr-subdir) RESULT_SUBDIR="$2"; shift;;
       --proc-id) PROCESS_ID="$2"; shift;;
@@ -95,7 +98,7 @@ init "$@"
 
   post_sync_workdir
 
-  post_validate_workdir
+  if ((VALIDATE)); then post_validate_workdir; fi
 
   post_process_to_procdir
 

--- a/process_mets.sh
+++ b/process_mets.sh
@@ -16,6 +16,7 @@ parse_args() {
   PROCESS_ID=
   TASK_ID=
   WORKFLOW=/workflows/ocr-workflow-default.sh
+  VALIDATE=1
   PAGES=
   IMAGES_GRP=DEFAULT
   RESULT_GRP=FULLTEXT
@@ -30,6 +31,7 @@ $0 [OPTIONS] METS
 where OPTIONS can be any/all of:
  --workflow FILE    workflow file to use for processing, default:
                     $WORKFLOW
+ --no-validate      skip comprehensive validation of workflow results
  --pages RANGE      selection of physical page range to process
  --img-grp GRP      fileGrp to read input images from, default:
                     $IMAGES_GRP
@@ -51,6 +53,7 @@ ENVIRONMENT VARIABLES:
 EOF
                  exit;;
       --workflow) WORKFLOW="$2"; shift;;
+      --no-validate) VALIDATE=0;;
       --img-grp) IMAGES_GRP="$2"; shift;;
       --ocr-grp) RESULT_GRP="$2"; shift;;
       --pages) PAGES="$2"; shift;;
@@ -88,7 +91,7 @@ init "$@"
 
   post_sync_workdir
 
-  post_validate_workdir
+  if ((VALIDATE)); then post_validate_workdir; fi
 
   post_process_to_mets
 


### PR DESCRIPTION
needed as a stopgap measure; currently needed because we must wait for adoption of https://github.com/OCR-D/core/pull/1066